### PR TITLE
Protect main with local hooks and branch rules

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+
+if [ "$branch" = "main" ]; then
+  echo "ERROR: commits to 'main' are blocked in this clone." >&2
+  echo "Create a feature branch and open a pull request instead." >&2
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while read local_ref local_sha remote_ref remote_sha
+do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "ERROR: direct pushes to 'main' are blocked in this clone." >&2
+    echo "Push a branch and merge via pull request instead." >&2
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary
- add repo-local pre-commit and pre-push hooks under .githooks to block direct work on main
- configure this clone to use .githooks via core.hooksPath
- enable minimal GitHub branch protection for main with pull requests required, force-pushes disabled, and deletions disabled

## Testing
- verified .githooks hook files are executable
- verified local core.hooksPath is set to .githooks
- verified GitHub protection settings via API