### PR TITLE
Documentation: update deployment and repo docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,11 @@
 # AGENTS.md
 
-This repository is set up for Codex-first development. Prefer the repo-local skills under `.agents/skills/` and the retained feature documents under `docs/specs/` before relying on historical Kiro workflow files.
+This repository is set up for Codex-first development. Prefer the repo-local skills under `.agents/skills/` and the retained feature documents under `docs/specs/`.
 
 ## Source Of Truth
 
 - Treat `docs/specs/**/requirements.md` as the canonical statement of expected behavior and acceptance criteria.
 - Treat `docs/specs/**/design.md` as the canonical statement of implementation intent and architecture.
-- Leave `.kiro/` intact as historical context unless the user explicitly asks to migrate or remove more of it.
 
 ## Git Hygiene
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Elm Tic-Tac-Toe
 
+Live app: [GitHub Pages demo](https://genthaler.github.io/elm-tic-tac-toe/)
+
 ## Project Guidance
 
-This repository is now structured for Codex-first development while preserving the original Kiro material for reference.
+This repository is now structured for Codex-first development.
 
 - Feature requirements and design documents live under `docs/specs/`.
 - Repo-local Codex guidance lives under `.agents/skills/`.
-- `.kiro/` is intentionally left intact as historical context and migration source material; it is not the primary contributor entry point.
 
 A sophisticated tic-tac-toe game built with Elm, showcasing advanced functional programming concepts, game theory algorithms, and modern web development practices.
+
+## Live Demo
+
+- GitHub Pages: [https://genthaler.github.io/elm-tic-tac-toe/](https://genthaler.github.io/elm-tic-tac-toe/)
 
 ## 🎮 Features
 
@@ -29,7 +34,7 @@ A sophisticated tic-tac-toe game built with Elm, showcasing advanced functional 
 
 ### Technical Excellence
 - **Functional Architecture**: Pure functions, immutable state, and type safety
-- **Comprehensive Testing**: 838+ tests covering all functionality and edge cases
+- **Comprehensive Testing**: 800+ automated tests covering gameplay, routing, workers, and animation flows
 - **Performance Optimized**: Bundle size reduced by 80% with advanced optimizations
 - **Clean Code**: Well-documented, maintainable codebase following Elm best practices
 - **Production Ready**: Hash-based routing with comprehensive production build testing
@@ -87,22 +92,20 @@ npm install
 
 ```bash
 # Start development server with hot reload
-npm run start:parcel
-
-# Build and serve production version
-npm run start
+npm run parcel
 
 # Build optimized production bundle
 npm run build
 
-# Serve built files (alternative)
+# Serve built files locally
 npm run serve
 
 # Run comprehensive test suite
 npm run test
 
-# Run tests with documentation verification
-npm run test:all
+# Run unit or integration subsets
+npm run test:unit
+npm run test:integration
 
 # Watch mode for test-driven development
 npm run test:watch
@@ -121,9 +124,6 @@ npm run review:fix
 
 # Run elm-review with performance benchmarking
 npm run review:perf
-
-# Run elm-review excluding tests directory
-npm run review:clean
 
 # Run elm-review with CI-friendly output (JSON format, no colors)
 npm run review:ci
@@ -220,7 +220,7 @@ config =
 # Build for production (required for workers and routing)
 npm run build
 
-# Start production test server with hash routing support
+# Start a local server for the built app
 npm run serve
 
 # Open http://localhost:3000 in browser
@@ -233,7 +233,16 @@ npm run serve
 
 Development servers don't properly support web worker compilation or hash routing testing.
 
-For detailed testing procedures, see `PRODUCTION_HASH_ROUTING_TEST_GUIDE.md`.
+For detailed web worker testing guidance, see [`docs/web-worker-testing.md`](/Users/bonj/Developer/Elm/elm-tic-tac-toe/docs/web-worker-testing.md).
+
+### Deployment
+
+```bash
+# Verify, build, and publish the dist/ directory to GitHub Pages
+npm run deploy
+```
+
+The deployed app is published at [https://genthaler.github.io/elm-tic-tac-toe/](https://genthaler.github.io/elm-tic-tac-toe/).
 
 ## 🏗️ Architecture & Development
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,11 +1,9 @@
 # Specs
 
-This directory retains the project requirements and design documents that were originally authored under `.kiro/specs/` and are now the primary feature-reference documents for Codex work in this repository.
+This directory retains the project requirements and design documents that are now the primary feature-reference documents for Codex work in this repository.
 
 - `requirements.md` files capture expected behavior and acceptance criteria.
 - `design.md` files capture implementation intent, architecture, and design tradeoffs.
-- `tasks.md` files remain under `.kiro/specs/` for historical reference only; they are not the active Codex workflow surface.
-
 These documents reflect a mix of implemented, partially implemented, and aspirational work. Treat them as feature-scoped references and reconcile them with the current code before changing behavior.
 
 Current feature areas:

--- a/docs/web-worker-testing.md
+++ b/docs/web-worker-testing.md
@@ -2,7 +2,7 @@
 
 ## Important: Production Build Required
 
-Web worker functionality **cannot be tested** using development servers like `npm run start:parcel`. Development mode compilation removes the DOM nodes and worker compilation needed for proper web worker functionality.
+Web worker functionality **cannot be tested** using the Parcel development server (`npm run parcel`). Development mode compilation removes the DOM nodes and worker compilation needed for proper web worker functionality.
 
 ## Correct Testing Procedure
 
@@ -31,10 +31,14 @@ When testing the tic-tac-toe game's AI functionality:
 
 ## Development Workflow
 
-- Use `npm run start:parcel` for UI development and non-worker features
-- Use `npm run build && npm run serve` when testing worker integration
+- Use `npm run parcel` for UI development and non-worker features
+- Use `npm run build` followed by `npm run serve` when testing worker integration
 - Run `npm run test` for unit tests (these don't require workers)
 - Always test worker functionality in production build before deployment
+
+## GitHub Pages
+
+The deployed app is available at [https://genthaler.github.io/elm-tic-tac-toe/](https://genthaler.github.io/elm-tic-tac-toe/).
 
 ## Browser Developer Tools
 


### PR DESCRIPTION
## Summary
- document the live GitHub Pages deployment and current npm script workflow
- remove stale references to the deleted .kiro directory from repo guidance docs
- replace outdated README claims and point production worker testing at docs/web-worker-testing.md

## Verification
- npm run test
- npm run build