### PR TITLE
Documentation: add README live app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Elm Tic-Tac-Toe
 
+Live app: [https://genthaler.github.io/elm-tic-tac-toe/](https://genthaler.github.io/elm-tic-tac-toe/)
+
 This repository contains a single-screen tic-tac-toe app built with Elm. It boots directly into the game, uses a shared theme module for light and dark color schemes, and runs AI move calculations in a web worker so the UI stays responsive.
 
 ## Project Guidance


### PR DESCRIPTION
## Summary
- add the deployed GitHub Pages URL to the top of the README

## Verification
- docs-only change