### PR TITLE
Refine search visualization spec

### DIFF
--- a/docs/specs/tic-tac-toe-game/design.md
+++ b/docs/specs/tic-tac-toe-game/design.md
@@ -27,7 +27,7 @@ graph TB
 
 1. **TicTacToe/Main.elm** - Application entry point, handles initialization, updates, subscriptions, worker wiring, theme persistence, and inspection-mode coordination
 2. **TicTacToe/Model.elm** - Defines the game model, board state, search-inspection state, status state, viewport state, and serialized theme preference
-3. **TicTacToe/View.elm** - Renders the responsive single-screen game interface and the search inspection controls with `elm-ui`
+3. **TicTacToe/View.elm** - Renders the responsive single-screen game interface, tree diagram, explanation panel, and synchronized board annotations with `elm-ui`
 4. **TicTacToe/TicTacToe.elm** - Core game logic, move validation, win detection, and round progression
 5. **TicTacToe/GameWorker.elm** - Web worker for fast-play AI computations
 6. **TicTacToe/SearchTrace*.elm** - Pure trace generation for instrumented Negamax and Alpha-Beta inspection
@@ -78,6 +78,7 @@ type Player
 type GameState
     = Waiting Player
     | Thinking Player
+    | Inspecting SearchAlgorithm
     | Winner Player
     | Draw
     | Error String
@@ -103,6 +104,11 @@ type alias Model =
 type SearchAlgorithm
     = Negamax
     | AlphaBeta
+
+type alias BranchColor =
+    { primary : Color
+    , muted : Color
+    }
 
 type NodeStatus
     = Unvisited
@@ -149,6 +155,7 @@ type alias SearchInspectionState =
     { trace : SearchTrace
     , eventIndex : Int
     , committed : Bool
+    , selectedNode : Maybe SearchNodeId
     }
 ```
 
@@ -166,6 +173,7 @@ type Msg
     | StartInspection SearchAlgorithm
     | StepInspectionBack
     | StepInspectionForward
+    | SelectInspectionNode SearchNodeId
     | ApplyInspectionMove
     | AutoPlayComputerMove
 ```
@@ -185,6 +193,75 @@ The instrumented search trace layer provides a separate pure API for teaching an
 - `stepTraceForward : SearchTrace -> Int -> SearchInspectionState`
 - `stepTraceBackward : SearchTrace -> Int -> SearchInspectionState`
 - `currentInspectionSnapshot : SearchInspectionState -> { node : Maybe SearchNode, event : Maybe SearchEvent }`
+- `rootMovePalette : SearchTrace -> Dict Position BranchColor`
+
+### Inspection Layout
+
+The inspection UI should use a three-region teaching layout on larger screens and a stacked layout on smaller screens:
+
+1. **Tree panel** - The primary visualization surface showing the explored decision tree
+2. **Board panel** - The main playable tic-tac-toe board with candidate-move annotations
+3. **Explanation panel** - Controls, longhand narration, compact formulas, and current node facts
+
+On mobile-sized layouts, the board remains first, the explanation panel remains immediately accessible, and the tree panel becomes stacked or horizontally scrollable rather than being removed.
+
+### Tree Visualization
+
+The tree diagram is the primary inspection surface rather than a secondary debug detail.
+
+- The tree should be shown as a true branching structure
+- Root candidate moves should receive stable distinct colors
+- Descendants should inherit muted variants of the root color so the branch origin stays visible
+- Nodes should show:
+  - score
+  - move label or compact board identity
+  - node status
+  - alpha and beta where relevant
+- The current node should have a strong active treatment
+- Traversed edges should be distinct from queued edges
+- Pruned branches should remain visible as faded or dashed ghosts instead of disappearing
+
+### Main Board Synchronization
+
+The board panel remains the user's main point of reference for playable moves.
+
+- Root candidate moves should be annotated directly on the main board
+- Candidate annotations should reuse the same stable branch colors used in the tree
+- The board should show current candidate scores near the root move positions
+- The current best-so-far move should be emphasized distinctly
+- Selecting or stepping to a tree node should update a synchronized board representation so the user can connect tree state to game state
+
+### Explanation Panel
+
+The explanation panel should explain both the current action and the algorithmic reason.
+
+- Longhand explanation text should describe the current step in plain language
+- A compact formula line should summarize the relevant calculation
+- Current node facts should include score, depth, move path, and in alpha-beta mode the current bounds
+- The panel should explain pruning explicitly rather than expecting the user to infer it from visuals alone
+
+Recommended sentence patterns:
+
+- "Exploring move top-left for O."
+- "Reached terminal position: X wins, so this leaf scores -1 for O."
+- "Returned from child center with score 3."
+- "Negamax flips the child score, so this branch becomes -3."
+- "Updated alpha from -inf to 3."
+- "Beta is now less than or equal to alpha, so the remaining siblings are pruned."
+
+### Visual Encoding
+
+To keep the tree readable, the view should not rely on color alone.
+
+- Root branch color identifies the candidate move
+- Node status identifies activity:
+  - active
+  - evaluating
+  - finalized
+  - pruned
+- Pruned branches should use reduced opacity and a non-solid stroke
+- Best-so-far root moves should be emphasized in both the tree and board panels
+- Alpha and beta values should be visually distinct from the node score itself
 
 ### Web Worker Communication
 
@@ -217,7 +294,7 @@ Game states follow a clear progression:
 
 - `Waiting Player` - Waiting for human or AI input
 - `Thinking Player` - AI is calculating the next move
-- `Inspecting SearchAlgorithm` - Search trace is available for stepping and review
+- `Inspecting SearchAlgorithm` - Search trace, selected node, and explanation state are available for stepping and review
 - `Winner Player` - Game ended with a winner
 - `Draw` - Game ended in a tie
 - `Error String` - Error state with message
@@ -243,6 +320,7 @@ The system tracks move timing to implement auto-play:
    - Trace generation failures
    - Invalid step indices
    - Attempting to apply a move before the trace has been inspected
+   - Selected nodes that no longer match the current event position
 
 3. **Communication Errors**
    - JSON encoding and decoding failures
@@ -274,6 +352,9 @@ The system tracks move timing to implement auto-play:
    - Trace generation for Negamax and Alpha-Beta
    - Stepping forward and backward through trace events
    - Alpha/beta bound updates and pruning metadata
+   - Root branch color stability and candidate-score annotations
+   - Tree node selection and synchronized board-preview behavior
+   - Explanation text generation for leaf evaluation, score propagation, and pruning
 
 2. **Model Testing**
    - JSON encoding and decoding round trips
@@ -286,6 +367,7 @@ The system tracks move timing to implement auto-play:
    - UI interaction flows
    - Inspection mode workflows
    - Applying the final move from an inspected trace
+   - Tree, board, and explanation panel staying synchronized through step changes
 
 ### Test Structure
 
@@ -333,7 +415,8 @@ Key properties to test:
    - SVG-based pieces for crisp scaling
    - Efficient `elm-ui` layout composition
    - Responsive layout adapts to viewport changes
-   - Inspection controls and trace panel remain legible on mobile and desktop
+   - Inspection controls, tree panel, and explanation panel remain legible on mobile and desktop
+   - Tree rendering should keep pruned nodes visible without overwhelming the main board
 
 ## Accessibility and Usability
 

--- a/docs/specs/tic-tac-toe-game/requirements.md
+++ b/docs/specs/tic-tac-toe-game/requirements.md
@@ -44,14 +44,42 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 2. WHEN inspection mode is active THEN the system SHALL allow stepping forward through search events
 3. WHEN inspection mode is active THEN the system SHALL allow stepping backward through search events
 4. WHEN inspection mode is active THEN the system SHALL show the currently active node or event
-5. WHEN inspection mode is active THEN the system SHALL show the values assigned to nodes and moves through the evaluation tree
-6. WHEN inspection mode is active THEN the system SHALL show the final best move determined by the search
-7. WHEN the Alpha-Beta trace is selected THEN the system SHALL show alpha and beta bounds
-8. WHEN the Alpha-Beta trace updates bounds THEN the system SHALL show the updated bounds in the visualization
-9. WHEN the Alpha-Beta trace prunes a branch THEN the system SHALL mark the pruned branch distinctly
-10. WHEN the player chooses to apply the final move THEN the system SHALL commit the best move and return to normal game flow
+5. WHEN inspection mode is active THEN the system SHALL render a tree diagram as the primary search visualization
+6. WHEN the tree diagram is shown THEN the system SHALL display node scores throughout the explored evaluation tree
+7. WHEN the tree diagram is shown THEN the system SHALL keep pruned branches visible in a visually de-emphasized state rather than removing them entirely
+8. WHEN the Alpha-Beta trace is selected THEN the system SHALL show alpha and beta bounds on relevant nodes
+9. WHEN the Alpha-Beta trace updates bounds THEN the system SHALL show the updated bounds in the visualization
+10. WHEN the Alpha-Beta trace prunes a branch THEN the system SHALL mark the pruned branch distinctly
+11. WHEN the system is showing alternative root moves THEN each prospective root move SHALL use a stable distinct color that is reused in the tree and board overlays
+12. WHEN inspection mode is active THEN the system SHALL show the final best move determined by the search
+13. WHEN the player chooses to apply the final move THEN the system SHALL commit the best move and return to normal game flow
 
 ### Requirement 4
+
+**User Story:** As a player, I want the main game board to stay synchronized with the search visualisation, so that I can connect abstract tree values back to playable moves.
+
+#### Acceptance Criteria
+
+1. WHEN inspection mode is active THEN the main game board SHALL remain visible alongside the search visualisation
+2. WHEN the root candidate moves are available THEN the main board SHALL annotate each candidate move with the corresponding branch color
+3. WHEN the root candidate moves are available THEN the main board SHALL show the current score for each candidate move
+4. WHEN a best-so-far move exists THEN the main board SHALL emphasise that move distinctly
+5. WHEN the player selects or steps to a node in the tree THEN the interface SHALL show the board state corresponding to that node in either the main board or a synchronized board preview
+
+### Requirement 5
+
+**User Story:** As a player, I want a clear explanation of each step, so that I can understand the calculations and decisions the algorithm is making.
+
+#### Acceptance Criteria
+
+1. WHEN inspection mode is active THEN the interface SHALL show a longhand explanation panel for the current step
+2. WHEN a leaf node is evaluated THEN the explanation SHALL state the resulting score and why that terminal or heuristic value applies
+3. WHEN a score is propagated upward THEN the explanation SHALL describe how the parent value changed
+4. WHEN Alpha-Beta updates a bound THEN the explanation SHALL describe the bound change
+5. WHEN Alpha-Beta prunes a branch THEN the explanation SHALL describe why the remaining branch cannot affect the decision
+6. WHEN helpful THEN the explanation panel SHALL include a compact formula-style summary of the current calculation
+
+### Requirement 6
 
 **User Story:** As a player, I want the game to detect terminal states, so that I know when the round is over.
 
@@ -64,7 +92,7 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 5. WHEN a game ends THEN the system SHALL prevent further moves on the board
 6. WHEN a game ends THEN the system SHALL display the result clearly
 
-### Requirement 5
+### Requirement 7
 
 **User Story:** As a player, I want to reset the game, so that I can start another round without reloading the page.
 
@@ -76,7 +104,7 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 4. WHEN the game is reset THEN the system SHALL keep the current color scheme
 5. WHEN the game is reset THEN the system SHALL be ready for a new round immediately
 
-### Requirement 6
+### Requirement 8
 
 **User Story:** As a player, I want clear status feedback, so that I can tell what the game is doing.
 
@@ -88,7 +116,7 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 4. WHEN the game ends in a draw THEN the system SHALL display a draw message
 5. WHEN an error occurs THEN the system SHALL display the error message clearly
 
-### Requirement 7
+### Requirement 9
 
 **User Story:** As a player, I want to switch themes, so that I can use the color scheme I prefer.
 
@@ -99,7 +127,7 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 3. WHEN the color scheme changes THEN the system SHALL update all UI elements consistently
 4. WHEN the app reloads THEN the system SHALL restore the persisted color scheme preference
 
-### Requirement 8
+### Requirement 10
 
 **User Story:** As a player, I want the game to handle slow interaction gracefully, so that it does not feel stuck.
 
@@ -110,7 +138,7 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 3. WHEN the auto-move is triggered THEN the system SHALL continue the normal game flow
 4. WHEN the human player makes a move before timeout THEN the system SHALL cancel the timer
 
-### Requirement 9
+### Requirement 11
 
 **User Story:** As a player, I want the app to remain responsive on different devices, so that it is usable on desktop and mobile.
 
@@ -120,4 +148,5 @@ This document defines the requirements for the single-screen tic-tac-toe applica
 2. WHEN the browser window is resized THEN the system SHALL adjust the layout accordingly
 3. WHEN the computer calculates moves THEN the system SHALL use a web worker to prevent UI blocking
 4. WHEN running on mobile devices THEN the system SHALL provide touch-friendly cell sizes and interactions
-5. WHEN inspection mode is shown THEN the system SHALL keep the algorithm controls and trace panel legible on small screens
+5. WHEN inspection mode is shown on larger screens THEN the system SHALL present distinct areas for the tree, board, and explanation controls
+6. WHEN inspection mode is shown on small screens THEN the system SHALL keep the board, explanation controls, and tree view legible through stacking or scrolling rather than hiding core information


### PR DESCRIPTION
## Summary
- refine the inspect-search requirements around a tree-first visualization
- specify synchronized board overlays, root-move colors, and longhand explanation text
- extend the design doc with layout, visual encoding, and testing expectations for the teaching UI

## Testing
- not run (docs-only change)
