### PR TITLE
Chore: override lodash for audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4945,9 +4945,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "serve": "^14.2.6",
     "shx": "^0.4.0"
   },
+  "overrides": {
+    "lodash": "4.18.1"
+  },
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "engines": {
     "node": ">= 20"


### PR DESCRIPTION
## Summary
- add npm override for lodash 4.18.1 to clear the new lodash advisories
- refresh package-lock.json

## Notes
- Remaining advisories are still in node-elm-compiler/cross-spawn with no fix available.

## Verification
- npm audit